### PR TITLE
fix deprecation notice since Symfony 3.4

### DIFF
--- a/src/DependencyInjection/Compiler/SetRouterPass.php
+++ b/src/DependencyInjection/Compiler/SetRouterPass.php
@@ -26,6 +26,10 @@ class SetRouterPass implements CompilerPassInterface
 
             // Update alias
             $container->setAlias('router', 'genedys_csrf_route.routing.router');
+            $alias = $container->getAlias('router');
+            if (method_exists($alias, 'setPrivate')) {
+                $alias->setPrivate(false);
+            }
         }
 
         // Replace Sensio Route annotation loader


### PR DESCRIPTION
All services are marked as private by default since Symfony 3.4 (https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default).
Aliases are still public, but if not configured to not be private, they trigger deprecation notice.
https://api.symfony.com/3.4/Symfony/Component/DependencyInjection/Alias.html#method_setPrivate